### PR TITLE
fix(security): harden tool execution against injection and traversal

### DIFF
--- a/tools/system_tools/file_tools.py
+++ b/tools/system_tools/file_tools.py
@@ -235,9 +235,11 @@ def register_file_tools(mcp: FastMCP):
             path = Path(file_path)
 
             # Security check: prevent writing to sensitive locations
+            # Resolve symlinks to prevent traversal bypasses
+            resolved = path.resolve()
             sensitive_paths = ["/etc", "/usr", "/bin", "/sbin", "/var", "/root"]
             for sensitive in sensitive_paths:
-                if str(path.absolute()).startswith(sensitive):
+                if str(resolved) == sensitive or str(resolved).startswith(sensitive + "/"):
                     return {
                         "status": "error",
                         "action": "write_file",


### PR DESCRIPTION
## Summary
- Switch bash_tools from create_subprocess_shell to create_subprocess_exec to prevent shell injection (#4)
- Resolve symlinks before path traversal checks in file_tools (#13)
- Add SSRF protection with URL allowlist for registry fetcher (#14)

## Test plan
- [ ] Verify shell metacharacters in commands don't execute arbitrary code
- [ ] Verify symlink-based path traversal is blocked
- [ ] Verify only allowlisted registry hosts are fetched (npm, GitHub)
- [ ] Verify private/loopback IPs are rejected in registry URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)