### PR TITLE
fix(contracts): move domain types from tests/ to service modules

### DIFF
--- a/services/aggregator_service/aggregator_service.py
+++ b/services/aggregator_service/aggregator_service.py
@@ -10,10 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.aggregator.data_contract import (
-    ServerTransportType,
-    ServerStatus,
-)
+from .domain import ServerTransportType, ServerStatus
 
 from .server_registry import ServerRegistry
 from .session_manager import SessionManager

--- a/services/aggregator_service/domain.py
+++ b/services/aggregator_service/domain.py
@@ -1,0 +1,35 @@
+"""
+Aggregator Service Domain Types.
+
+Canonical enums and types for the aggregator service.
+These are the production source of truth — test contracts re-export from here.
+"""
+
+from enum import Enum
+
+
+class ServerTransportType(str, Enum):
+    """Transport types for external MCP servers."""
+
+    STDIO = "STDIO"
+    SSE = "SSE"
+    HTTP = "HTTP"
+    STREAMABLE_HTTP = "STREAMABLE_HTTP"
+
+
+class ServerStatus(str, Enum):
+    """Connection status of external MCP server."""
+
+    CONNECTED = "CONNECTED"
+    DISCONNECTED = "DISCONNECTED"
+    ERROR = "ERROR"
+    CONNECTING = "CONNECTING"
+    DEGRADED = "DEGRADED"
+
+
+class RoutingStrategy(str, Enum):
+    """How routing decision was made."""
+
+    NAMESPACE_RESOLVED = "namespace_resolved"
+    EXPLICIT_SERVER = "explicit_server"
+    FALLBACK = "fallback"

--- a/services/aggregator_service/request_router.py
+++ b/services/aggregator_service/request_router.py
@@ -9,10 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
 import logging
 
-from tests.contracts.aggregator.data_contract import (
-    ServerStatus,
-    RoutingStrategy,
-)
+from .domain import ServerStatus, RoutingStrategy
 
 logger = logging.getLogger(__name__)
 

--- a/services/aggregator_service/server_registry.py
+++ b/services/aggregator_service/server_registry.py
@@ -9,10 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.aggregator.data_contract import (
-    ServerTransportType,
-    ServerStatus,
-)
+from .domain import ServerTransportType, ServerStatus
 
 logger = logging.getLogger(__name__)
 

--- a/services/aggregator_service/session_manager.py
+++ b/services/aggregator_service/session_manager.py
@@ -16,10 +16,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.aggregator.data_contract import (
-    ServerTransportType,
-    ServerStatus,
-)
+from .domain import ServerTransportType, ServerStatus
 
 logger = logging.getLogger(__name__)
 

--- a/services/aggregator_service/tool_aggregator.py
+++ b/services/aggregator_service/tool_aggregator.py
@@ -7,9 +7,7 @@ Handles tool discovery, namespacing, embedding generation, and skill classificat
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.aggregator.data_contract import (
-    ServerStatus,
-)
+from .domain import ServerStatus
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/__init__.py
+++ b/services/marketplace_service/__init__.py
@@ -27,15 +27,20 @@ from .package_resolver import PackageResolver
 from .install_manager import InstallManager
 from .update_manager import UpdateManager
 
-# Re-export contracts for convenience
-from tests.contracts.marketplace import (
+# Re-export domain types for convenience
+from .domain import (
     RegistrySource,
     InstallStatus,
     UpdateChannel,
     PackageSpec,
     InstallResult,
-    SearchResult,
 )
+
+# SearchResult is a test-only contract, not needed in production
+try:
+    from tests.contracts.marketplace import SearchResult
+except ImportError:
+    SearchResult = None  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/domain.py
+++ b/services/marketplace_service/domain.py
@@ -1,0 +1,121 @@
+"""
+Marketplace Service Domain Types.
+
+Canonical enums and dataclasses for the marketplace service.
+These are the production source of truth — test contracts re-export from here.
+"""
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Enums
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class RegistrySource(str, Enum):
+    NPM = "npm"
+    GITHUB = "github"
+    ISA_CLOUD = "isa-cloud"
+    PRIVATE = "private"
+    LOCAL = "local"
+
+
+class InstallStatus(str, Enum):
+    INSTALLED = "installed"
+    DISABLED = "disabled"
+    ERROR = "error"
+    UPDATING = "updating"
+    UNINSTALLING = "uninstalling"
+
+
+class UpdateChannel(str, Enum):
+    STABLE = "stable"
+    BETA = "beta"
+    LATEST = "latest"
+
+
+class SyncType(str, Enum):
+    FULL = "full"
+    INCREMENTAL = "incremental"
+    SINGLE_PACKAGE = "single_package"
+
+
+class SyncStatus(str, Enum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Service Contracts (Request/Response Types used by production code)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@dataclass
+class PackageSpec:
+    """Package specification for installation."""
+
+    name: str
+    version: Optional[str] = None
+    registry: Optional[RegistrySource] = None
+    config: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        if not re.match(r"^(@[a-z0-9-]+/)?[a-z0-9-]+$", self.name):
+            raise ValueError(f"Invalid package name format: {self.name}")
+
+
+@dataclass
+class InstallResult:
+    """Result of package installation."""
+
+    success: bool
+    package_id: str
+    package_name: str
+    version: str
+
+    server_id: Optional[str] = None
+    tools_discovered: int = 0
+    skills_assigned: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "success": self.success,
+            "package_id": self.package_id,
+            "package_name": self.package_name,
+            "version": self.version,
+            "server_id": self.server_id,
+            "tools_discovered": self.tools_discovered,
+            "skills_assigned": self.skills_assigned,
+            "error": self.error,
+        }
+
+
+@dataclass
+class UpdateInfo:
+    """Information about available package update."""
+
+    package_id: str
+    package_name: str
+    current_version: str
+    latest_version: str
+    update_channel: UpdateChannel
+    changelog: Optional[str] = None
+    breaking_changes: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "package_id": self.package_id,
+            "package_name": self.package_name,
+            "current_version": self.current_version,
+            "latest_version": self.latest_version,
+            "update_channel": self.update_channel.value,
+            "changelog": self.changelog,
+            "breaking_changes": self.breaking_changes,
+        }

--- a/services/marketplace_service/install_manager.py
+++ b/services/marketplace_service/install_manager.py
@@ -13,7 +13,7 @@ import re
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.marketplace import InstallStatus, InstallResult
+from .domain import InstallStatus, InstallResult
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/marketplace_service.py
+++ b/services/marketplace_service/marketplace_service.py
@@ -10,12 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.marketplace import (
-    RegistrySource,
-    InstallStatus,
-    PackageSpec,
-    InstallResult,
-)
+from .domain import RegistrySource, InstallStatus, PackageSpec, InstallResult
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/package_repository.py
+++ b/services/marketplace_service/package_repository.py
@@ -14,11 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.marketplace import (
-    RegistrySource,
-    InstallStatus,
-    UpdateChannel,
-)
+from .domain import RegistrySource, InstallStatus, UpdateChannel
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/package_resolver.py
+++ b/services/marketplace_service/package_resolver.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import logging
 import re
 
-from tests.contracts.marketplace import PackageSpec, RegistrySource
+from .domain import PackageSpec, RegistrySource
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/registry_fetcher.py
+++ b/services/marketplace_service/registry_fetcher.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 import logging
 import re
 
-from tests.contracts.marketplace import RegistrySource
+from .domain import RegistrySource
 
 logger = logging.getLogger(__name__)
 

--- a/services/marketplace_service/update_manager.py
+++ b/services/marketplace_service/update_manager.py
@@ -10,13 +10,7 @@ Handles:
 from typing import Any, Dict, List, Optional
 import logging
 
-from tests.contracts.marketplace import (
-    InstallStatus,
-    UpdateChannel,
-    InstallResult,
-    UpdateInfo,
-    PackageSpec,
-)
+from .domain import InstallStatus, UpdateChannel, InstallResult, UpdateInfo, PackageSpec
 
 logger = logging.getLogger(__name__)
 

--- a/tests/contracts/aggregator/__init__.py
+++ b/tests/contracts/aggregator/__init__.py
@@ -9,8 +9,8 @@ Contracts:
 - system_contract.md: API contracts and integration points
 """
 
-from tests.contracts.aggregator.data_contract import (
-    # Enums
+from .data_contract import (
+    # Enums (re-exported from services.aggregator_service.domain)
     ServerTransportType,
     ServerStatus,
     RoutingStrategy,

--- a/tests/contracts/aggregator/data_contract.py
+++ b/tests/contracts/aggregator/data_contract.py
@@ -18,32 +18,12 @@ from enum import Enum
 # ============================================================================
 
 
-class ServerTransportType(str, Enum):
-    """Transport types for external MCP servers."""
-
-    STDIO = "STDIO"  # Standard input/output (local process)
-    SSE = "SSE"  # Server-Sent Events (HTTP streaming)
-    HTTP = "HTTP"  # Standard HTTP request/response
-    STREAMABLE_HTTP = "STREAMABLE_HTTP"  # MCP Streamable HTTP (bidirectional)
-
-
-class ServerStatus(str, Enum):
-    """Connection status of external MCP server."""
-
-    CONNECTED = "CONNECTED"  # Server connected and healthy
-    DISCONNECTED = "DISCONNECTED"  # Server intentionally disconnected
-    ERROR = "ERROR"  # Server unreachable or failing
-    CONNECTING = "CONNECTING"  # Connection in progress
-    DEGRADED = "DEGRADED"  # Connected but elevated errors
-
-
-class RoutingStrategy(str, Enum):
-    """How routing decision was made."""
-
-    NAMESPACE_RESOLVED = "namespace_resolved"  # Parsed from namespaced name
-    EXPLICIT_SERVER = "explicit_server"  # Server ID provided
-    FALLBACK = "fallback"  # Using fallback server
-
+# Import canonical enums from service domain (single source of truth)
+from services.aggregator_service.domain import (  # noqa: E402
+    ServerTransportType,
+    ServerStatus,
+    RoutingStrategy,
+)
 
 # ============================================================================
 # Request Contracts (Input Schemas)

--- a/tests/contracts/marketplace/data_contract.py
+++ b/tests/contracts/marketplace/data_contract.py
@@ -18,69 +18,17 @@ from typing import Any, Dict, List, Optional
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-class RegistrySource(str, Enum):
-    """
-    Supported package registry sources.
-
-    Database column: mcp.marketplace_packages.registry_source
-    """
-
-    NPM = "npm"  # npm registry (npmjs.com)
-    GITHUB = "github"  # GitHub releases
-    ISA_CLOUD = "isa-cloud"  # isA Cloud marketplace
-    PRIVATE = "private"  # Private enterprise registry
-    LOCAL = "local"  # Local file-based package
-
-
-class InstallStatus(str, Enum):
-    """
-    Package installation status.
-
-    Database column: mcp.installed_packages.status
-    """
-
-    INSTALLED = "installed"  # Package installed and active
-    DISABLED = "disabled"  # Package disabled but not removed
-    ERROR = "error"  # Installation/connection error
-    UPDATING = "updating"  # Update in progress
-    UNINSTALLING = "uninstalling"  # Uninstall in progress
-
-
-class UpdateChannel(str, Enum):
-    """
-    Update channel for packages.
-
-    Database column: mcp.installed_packages.update_channel
-    """
-
-    STABLE = "stable"  # Stable releases only
-    BETA = "beta"  # Include beta releases
-    LATEST = "latest"  # Always use latest (including prereleases)
-
-
-class SyncType(str, Enum):
-    """
-    Registry synchronization type.
-
-    Database column: mcp.registry_sync_log.sync_type
-    """
-
-    FULL = "full"  # Full registry sync
-    INCREMENTAL = "incremental"  # Only changed packages
-    SINGLE_PACKAGE = "single_package"  # Single package update
-
-
-class SyncStatus(str, Enum):
-    """
-    Registry synchronization status.
-
-    Database column: mcp.registry_sync_log.status
-    """
-
-    RUNNING = "running"  # Sync in progress
-    COMPLETED = "completed"  # Sync completed successfully
-    FAILED = "failed"  # Sync failed
-
+# Import canonical types from service domain (single source of truth)
+from services.marketplace_service.domain import (  # noqa: E402
+    RegistrySource,
+    InstallStatus,
+    UpdateChannel,
+    SyncType,
+    SyncStatus,
+    PackageSpec,
+    InstallResult,
+    UpdateInfo,
+)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Database Record Contracts
@@ -442,57 +390,8 @@ class RegistrySyncLogContract:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-@dataclass
-class PackageSpec:
-    """
-    Package specification for installation.
-
-    Used as input to MarketplaceService.install()
-    """
-
-    name: str  # Package name
-    version: Optional[str] = None  # Specific version (None = latest)
-    registry: Optional[RegistrySource] = None  # Specific registry
-    config: Optional[Dict[str, Any]] = None  # User configuration (API keys, etc.)
-
-    def __post_init__(self):
-        """Validate package name format."""
-        import re
-
-        if not re.match(r"^(@[a-z0-9-]+/)?[a-z0-9-]+$", self.name):
-            raise ValueError(f"Invalid package name format: {self.name}")
-
-
-@dataclass
-class InstallResult:
-    """
-    Result of package installation.
-
-    Returned by MarketplaceService.install()
-    """
-
-    success: bool
-    package_id: str
-    package_name: str
-    version: str
-
-    server_id: Optional[str] = None
-    tools_discovered: int = 0
-    skills_assigned: List[str] = field(default_factory=list)
-    error: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for API responses."""
-        return {
-            "success": self.success,
-            "package_id": self.package_id,
-            "package_name": self.package_name,
-            "version": self.version,
-            "server_id": self.server_id,
-            "tools_discovered": self.tools_discovered,
-            "skills_assigned": self.skills_assigned,
-            "error": self.error,
-        }
+# PackageSpec, InstallResult, and UpdateInfo are now imported from
+# services.marketplace_service.domain above.
 
 
 @dataclass
@@ -524,33 +423,7 @@ class SearchResult:
         }
 
 
-@dataclass
-class UpdateInfo:
-    """
-    Information about available package update.
-
-    Returned by MarketplaceService.check_updates()
-    """
-
-    package_id: str
-    package_name: str
-    current_version: str
-    latest_version: str
-    update_channel: UpdateChannel
-    changelog: Optional[str] = None
-    breaking_changes: bool = False
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for API responses."""
-        return {
-            "package_id": self.package_id,
-            "package_name": self.package_name,
-            "current_version": self.current_version,
-            "latest_version": self.latest_version,
-            "update_channel": self.update_channel.value,
-            "changelog": self.changelog,
-            "breaking_changes": self.breaking_changes,
-        }
+# UpdateInfo is now imported from services.marketplace_service.domain above.
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Create canonical domain.py modules in aggregator_service and marketplace_service (#5)
- Update 12 production service files to import from .domain instead of tests.contracts
- Update test contracts to re-export from domain modules (single source of truth)

## Test plan
- [ ] Verify all service imports resolve correctly
- [ ] Verify test contracts still work via re-exports
- [ ] Verify no circular import issues between domain and service modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)