### PR TITLE
fix(multi-tenant): add missing tenant isolation to skill, resource, marketplace

### DIFF
--- a/services/marketplace_service/migrations/002_add_multi_tenant_fields.sql
+++ b/services/marketplace_service/migrations/002_add_multi_tenant_fields.sql
@@ -1,0 +1,38 @@
+-- Migration 002: Add multi-tenant fields to marketplace tables
+-- Adds org_id and is_global to marketplace_packages and package_versions
+-- for org-private package support.
+-- Existing packages become global (visible to all orgs).
+
+-- marketplace_packages
+ALTER TABLE mcp.marketplace_packages ADD COLUMN IF NOT EXISTS org_id UUID;
+ALTER TABLE mcp.marketplace_packages ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT TRUE;
+UPDATE mcp.marketplace_packages SET is_global = TRUE WHERE is_global IS NULL;
+
+-- package_versions
+ALTER TABLE mcp.package_versions ADD COLUMN IF NOT EXISTS org_id UUID;
+ALTER TABLE mcp.package_versions ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT TRUE;
+UPDATE mcp.package_versions SET is_global = TRUE WHERE is_global IS NULL;
+
+-- Replace global unique name constraint with scoped ones
+ALTER TABLE mcp.marketplace_packages DROP CONSTRAINT IF EXISTS marketplace_packages_name_key;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_marketplace_packages_name_global
+    ON mcp.marketplace_packages(name) WHERE is_global = TRUE;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_marketplace_packages_name_org
+    ON mcp.marketplace_packages(name, org_id) WHERE org_id IS NOT NULL;
+
+-- Composite indexes for tenant filtering
+CREATE INDEX IF NOT EXISTS idx_marketplace_packages_tenant_filter
+    ON mcp.marketplace_packages(org_id, is_global);
+CREATE INDEX IF NOT EXISTS idx_package_versions_tenant_filter
+    ON mcp.package_versions(org_id, is_global);
+
+-- DOWN / ROLLBACK:
+-- DROP INDEX IF EXISTS idx_package_versions_tenant_filter;
+-- DROP INDEX IF EXISTS idx_marketplace_packages_tenant_filter;
+-- DROP INDEX IF EXISTS idx_marketplace_packages_name_org;
+-- DROP INDEX IF EXISTS idx_marketplace_packages_name_global;
+-- ALTER TABLE mcp.marketplace_packages ADD CONSTRAINT marketplace_packages_name_key UNIQUE (name);
+-- ALTER TABLE mcp.package_versions DROP COLUMN IF EXISTS is_global;
+-- ALTER TABLE mcp.package_versions DROP COLUMN IF EXISTS org_id;
+-- ALTER TABLE mcp.marketplace_packages DROP COLUMN IF EXISTS is_global;
+-- ALTER TABLE mcp.marketplace_packages DROP COLUMN IF EXISTS org_id;

--- a/services/resource_service/migrations/004_add_org_id.sql
+++ b/services/resource_service/migrations/004_add_org_id.sql
@@ -3,6 +3,11 @@
 -- Adding org_id enables organization-scoped resource filtering.
 
 ALTER TABLE mcp.resources ADD COLUMN IF NOT EXISTS org_id UUID;
+ALTER TABLE mcp.resources ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT TRUE;
+UPDATE mcp.resources SET is_global = TRUE WHERE is_global IS NULL;
 
--- Index for org-scoped resource queries
+-- Composite index matching tools/prompts pattern for tenant-filtered queries
+-- Supports: WHERE (is_global = TRUE OR org_id = $1)
+CREATE INDEX IF NOT EXISTS idx_resources_tenant_filter ON mcp.resources(org_id, is_global);
+-- Keep single-column index for backwards compatibility
 CREATE INDEX IF NOT EXISTS idx_resources_org_id ON mcp.resources(org_id);

--- a/services/skill_service/migrations/004_add_multi_tenant_fields.sql
+++ b/services/skill_service/migrations/004_add_multi_tenant_fields.sql
@@ -1,0 +1,27 @@
+-- Migration 004: Add multi-tenant fields to skill tables
+-- Adds org_id and is_global for hybrid multi-tenancy support.
+-- Existing skills become global (visible to all orgs).
+
+-- skill_categories
+ALTER TABLE mcp.skill_categories ADD COLUMN IF NOT EXISTS org_id UUID;
+ALTER TABLE mcp.skill_categories ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT TRUE;
+UPDATE mcp.skill_categories SET is_global = TRUE WHERE is_global IS NULL;
+
+-- tool_skill_assignments
+ALTER TABLE mcp.tool_skill_assignments ADD COLUMN IF NOT EXISTS org_id UUID;
+ALTER TABLE mcp.tool_skill_assignments ADD COLUMN IF NOT EXISTS is_global BOOLEAN DEFAULT TRUE;
+UPDATE mcp.tool_skill_assignments SET is_global = TRUE WHERE is_global IS NULL;
+
+-- Composite index for tenant-filtered queries
+CREATE INDEX IF NOT EXISTS idx_skill_categories_tenant_filter
+    ON mcp.skill_categories(org_id, is_global);
+CREATE INDEX IF NOT EXISTS idx_tool_skill_assignments_tenant_filter
+    ON mcp.tool_skill_assignments(org_id, is_global);
+
+-- DOWN / ROLLBACK:
+-- DROP INDEX IF EXISTS idx_tool_skill_assignments_tenant_filter;
+-- DROP INDEX IF EXISTS idx_skill_categories_tenant_filter;
+-- ALTER TABLE mcp.tool_skill_assignments DROP COLUMN IF EXISTS is_global;
+-- ALTER TABLE mcp.tool_skill_assignments DROP COLUMN IF EXISTS org_id;
+-- ALTER TABLE mcp.skill_categories DROP COLUMN IF EXISTS is_global;
+-- ALTER TABLE mcp.skill_categories DROP COLUMN IF EXISTS org_id;


### PR DESCRIPTION
## Summary
- Add org_id/is_global columns to skill_categories and tool_skill_assignments with migration (#8)
- Add composite tenant filter index to resources table (#18)
- Add org scoping to marketplace_packages and package_versions with migration (#19)

## Test plan
- [ ] Verify skill queries filter by org_id when provided, include global skills
- [ ] Verify resource queries use composite (org_id, is_global) index
- [ ] Verify marketplace package names are unique within org scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)