### PR TITLE
fix: add vector ID overflow detection, Qdrant retry logic, and cache versioning

### DIFF
--- a/core/cache/redis_cache.py
+++ b/core/cache/redis_cache.py
@@ -1,0 +1,236 @@
+"""
+Redis Cache Layer for MCP Services
+
+Provides caching for tools, prompts, and resources to reduce database load.
+Uses the cache prefixes defined in mcp_config.py.
+"""
+
+import json
+import logging
+import hashlib
+from typing import Any, Optional, List, Callable, TypeVar
+from functools import wraps
+
+from isa_common import AsyncRedisClient
+from core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Cache TTLs (in seconds)
+CACHE_TTL = {
+    "tool": 300,  # 5 minutes
+    "tool_list": 60,  # 1 minute (lists change more frequently)
+    "prompt": 300,  # 5 minutes
+    "resource": 300,  # 5 minutes
+    "search": 30,  # 30 seconds (search results are dynamic)
+    "skill": 600,  # 10 minutes (skills are more static)
+}
+
+# Cache version — increment when schema migrations change cached data format.
+# This ensures stale data from a previous schema is never served.
+CACHE_VERSION = 1
+
+# Cache key prefixes (from mcp_config.py)
+CACHE_PREFIX = f"mcp:cache:v{CACHE_VERSION}:"
+
+
+class RedisCache:
+    """Redis cache wrapper for MCP services"""
+
+    _instance: Optional["RedisCache"] = None
+
+    def __init__(self):
+        settings = get_settings()
+        self._client = AsyncRedisClient(
+            host=settings.infrastructure.redis_host,
+            port=settings.infrastructure.redis_port,
+            user_id="mcp-cache-service",
+        )
+        self._enabled = True
+
+    @classmethod
+    def get_instance(cls) -> "RedisCache":
+        """Get singleton instance"""
+        if cls._instance is None:
+            cls._instance = RedisCache()
+        return cls._instance
+
+    def _make_key(self, namespace: str, key: str) -> str:
+        """Create cache key with prefix"""
+        return f"{CACHE_PREFIX}{namespace}:{key}"
+
+    def _hash_params(self, params: dict) -> str:
+        """Create hash from parameters for cache key"""
+        param_str = json.dumps(params, sort_keys=True, default=str)
+        return hashlib.md5(param_str.encode()).hexdigest()[:12]
+
+    async def get(self, namespace: str, key: str) -> Optional[Any]:
+        """Get value from cache"""
+        if not self._enabled:
+            return None
+
+        try:
+            cache_key = self._make_key(namespace, key)
+            async with self._client:
+                value = await self._client.get(cache_key)
+
+            if value:
+                logger.debug(f"Cache HIT: {cache_key}")
+                return json.loads(value)
+
+            logger.debug(f"Cache MISS: {cache_key}")
+            return None
+        except Exception as e:
+            logger.warning(f"Cache get error: {e}")
+            return None
+
+    async def set(self, namespace: str, key: str, value: Any, ttl: Optional[int] = None) -> bool:
+        """Set value in cache with TTL"""
+        if not self._enabled:
+            return False
+
+        try:
+            cache_key = self._make_key(namespace, key)
+            ttl = ttl or CACHE_TTL.get(namespace, 300)
+
+            async with self._client:
+                await self._client.set(cache_key, json.dumps(value, default=str), ttl_seconds=ttl)
+
+            logger.debug(f"Cache SET: {cache_key} (TTL: {ttl}s)")
+            return True
+        except Exception as e:
+            logger.warning(f"Cache set error: {e}")
+            return False
+
+    async def delete(self, namespace: str, key: str) -> bool:
+        """Delete value from cache"""
+        if not self._enabled:
+            return False
+
+        try:
+            cache_key = self._make_key(namespace, key)
+            async with self._client:
+                await self._client.delete(cache_key)
+
+            logger.debug(f"Cache DELETE: {cache_key}")
+            return True
+        except Exception as e:
+            logger.warning(f"Cache delete error: {e}")
+            return False
+
+    async def invalidate_pattern(self, pattern: str) -> int:
+        """Invalidate all keys matching pattern.
+
+        Uses batched SCAN to handle large key sets without missing keys.
+        """
+        if not self._enabled:
+            return 0
+
+        try:
+            full_pattern = f"{CACHE_PREFIX}{pattern}*"
+            total_deleted = 0
+            batch_size = 10000
+
+            async with self._client:
+                while True:
+                    keys = await self._client.list_keys(full_pattern, limit=batch_size)
+                    if not keys:
+                        break
+                    await self._client.delete_multiple(keys)
+                    total_deleted += len(keys)
+                    # If we got fewer than batch_size, we've exhausted all matches
+                    if len(keys) < batch_size:
+                        break
+
+            logger.debug(f"Cache INVALIDATE: {full_pattern} ({total_deleted} keys)")
+            return total_deleted
+        except Exception as e:
+            logger.warning(f"Cache invalidate error: {e}")
+            return 0
+
+    async def invalidate_tool(self, tool_id: Optional[int] = None, tool_name: Optional[str] = None):
+        """Invalidate tool cache entries"""
+        if tool_id:
+            await self.delete("tool", f"id:{tool_id}")
+        if tool_name:
+            await self.delete("tool", f"name:{tool_name}")
+        # Also invalidate tool lists
+        await self.invalidate_pattern("tool_list:")
+        await self.invalidate_pattern("search:")
+
+    async def invalidate_prompt(
+        self, prompt_id: Optional[int] = None, prompt_name: Optional[str] = None
+    ):
+        """Invalidate prompt cache entries"""
+        if prompt_id:
+            await self.delete("prompt", f"id:{prompt_id}")
+        if prompt_name:
+            await self.delete("prompt", f"name:{prompt_name}")
+        await self.invalidate_pattern("prompt_list:")
+
+    async def invalidate_resource(
+        self, resource_id: Optional[int] = None, uri: Optional[str] = None
+    ):
+        """Invalidate resource cache entries"""
+        if resource_id:
+            await self.delete("resource", f"id:{resource_id}")
+        if uri:
+            await self.delete("resource", f"uri:{uri}")
+        await self.invalidate_pattern("resource_list:")
+
+
+# Global cache instance
+_cache: Optional[RedisCache] = None
+
+
+def get_cache() -> RedisCache:
+    """Get global cache instance"""
+    global _cache
+    if _cache is None:
+        _cache = RedisCache.get_instance()
+    return _cache
+
+
+def cached(
+    namespace: str, key_func: Optional[Callable[..., str]] = None, ttl: Optional[int] = None
+):
+    """
+    Decorator to cache async function results.
+
+    Usage:
+        @cached('tool', key_func=lambda tool_id: f"id:{tool_id}")
+        async def get_tool_by_id(self, tool_id: int):
+            ...
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> T:
+            cache = get_cache()
+
+            # Generate cache key
+            if key_func:
+                # Skip 'self' argument if method
+                cache_key = key_func(*args[1:], **kwargs) if args else key_func(**kwargs)
+            else:
+                # Auto-generate key from function name and args
+                params = {"args": args[1:] if args else (), "kwargs": kwargs}
+                cache_key = f"{func.__name__}:{cache._hash_params(params)}"
+
+            # Try cache first
+            cached_value = await cache.get(namespace, cache_key)
+            if cached_value is not None:
+                return cached_value
+
+            # Call function and cache result
+            result = await func(*args, **kwargs)
+            if result is not None:
+                await cache.set(namespace, cache_key, result, ttl)
+
+            return result
+
+        return wrapper
+
+    return decorator

--- a/tests/unit/test_redis_cache_versioning.py
+++ b/tests/unit/test_redis_cache_versioning.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for Redis cache versioning and pattern invalidation.
+
+Tests the cache improvements in PR #31:
+- Cache version prefix
+- Batched pattern invalidation
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from core.cache.redis_cache import RedisCache, CACHE_VERSION, CACHE_PREFIX
+
+
+class TestCacheVersioning:
+    """Test cache versioning (#17)."""
+
+    def test_cache_version_in_prefix(self):
+        """Cache prefix should include version number."""
+        assert f"v{CACHE_VERSION}" in CACHE_PREFIX
+        assert CACHE_PREFIX == f"mcp:cache:v{CACHE_VERSION}:"
+
+    def test_versioned_cache_keys(self):
+        """Cache keys should be prefixed with version."""
+        mock_client = AsyncMock()
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        # Check that keys include version prefix
+        key = cache._make_key("tool", "id:123")
+        assert key == f"mcp:cache:v{CACHE_VERSION}:tool:id:123"
+
+    @pytest.mark.asyncio
+    async def test_version_change_invalidates_old_cache(self):
+        """Changing CACHE_VERSION should make old keys inaccessible."""
+        mock_client = AsyncMock()
+        mock_client.get.return_value = None  # Old key not found
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        # Try to get data from old cache (different version)
+        result = await cache.get("tool", "id:123")
+
+        # Should call get with versioned key
+        call_args = mock_client.get.call_args[0][0]
+        assert f"v{CACHE_VERSION}" in call_args
+        assert result is None  # Old cache miss
+
+
+class TestBatchedPatternInvalidation:
+    """Test batched SCAN invalidation (#17)."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_single_batch(self):
+        """Should handle <10k keys in single batch."""
+        mock_client = AsyncMock()
+        # Return 100 keys, then empty (all keys in first batch)
+        mock_client.list_keys.side_effect = [
+            [f"mcp:cache:v1:tool:id:{i}" for i in range(100)],
+            [],
+        ]
+        mock_client.delete_multiple = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        deleted = await cache.invalidate_pattern("tool:")
+
+        assert deleted == 100
+        assert mock_client.list_keys.call_count == 1
+        assert mock_client.delete_multiple.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_multiple_batches(self):
+        """Should handle >10k keys across multiple batches."""
+        mock_client = AsyncMock()
+
+        # Simulate 25k keys across 3 batches
+        batch_1 = [f"key_{i}" for i in range(10000)]  # Full batch
+        batch_2 = [f"key_{i}" for i in range(10000, 20000)]  # Full batch
+        batch_3 = [f"key_{i}" for i in range(20000, 25000)]  # Partial (5k keys)
+
+        mock_client.list_keys.side_effect = [batch_1, batch_2, batch_3]
+        mock_client.delete_multiple = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        deleted = await cache.invalidate_pattern("tool:")
+
+        assert deleted == 25000
+        assert mock_client.list_keys.call_count == 3
+        assert mock_client.delete_multiple.call_count == 3
+
+        # Verify batch size parameter
+        for call in mock_client.list_keys.call_args_list:
+            assert call[1]["limit"] == 10000
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_stops_on_partial_batch(self):
+        """Should stop when batch size < limit (exhausted results)."""
+        mock_client = AsyncMock()
+
+        # Return partial batch (< 10k) on first call
+        mock_client.list_keys.return_value = [f"key_{i}" for i in range(500)]
+        mock_client.delete_multiple = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        deleted = await cache.invalidate_pattern("tool:")
+
+        assert deleted == 500
+        # Should not call list_keys again after partial batch
+        assert mock_client.list_keys.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_handles_errors(self):
+        """Should return 0 and log warning on errors."""
+        mock_client = AsyncMock()
+        mock_client.list_keys.side_effect = Exception("Redis connection error")
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        deleted = await cache.invalidate_pattern("tool:")
+
+        assert deleted == 0  # Error returns 0
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pattern_respects_version_prefix(self):
+        """Pattern invalidation should use versioned prefix."""
+        mock_client = AsyncMock()
+        mock_client.list_keys.return_value = []
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        await cache.invalidate_pattern("tool:")
+
+        # Verify the pattern includes version prefix
+        call_args = mock_client.list_keys.call_args[0][0]
+        assert call_args == f"mcp:cache:v{CACHE_VERSION}:tool:*"
+
+
+class TestCacheInvalidationHelpers:
+    """Test specific invalidation helper methods."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_tool(self):
+        """Should invalidate specific tool and tool lists."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+        mock_client.delete = AsyncMock()
+        mock_client.list_keys.return_value = []  # For pattern invalidation
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        await cache.invalidate_tool(tool_id=123, tool_name="test_tool")
+
+        # Should delete specific keys and invalidate patterns
+        assert mock_client.delete.call_count == 2  # id and name keys
+        assert mock_client.list_keys.call_count == 2  # tool_list and search patterns
+
+    @pytest.mark.asyncio
+    async def test_invalidate_prompt(self):
+        """Should invalidate specific prompt and prompt lists."""
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+        mock_client.delete = AsyncMock()
+        mock_client.list_keys.return_value = []
+
+        cache = RedisCache.__new__(RedisCache)
+        cache._client = mock_client
+        cache._enabled = True
+
+        await cache.invalidate_prompt(prompt_id=456)
+
+        assert mock_client.delete.call_count == 1  # id key only
+        assert mock_client.list_keys.call_count == 1  # prompt_list pattern

--- a/tests/unit/test_vector_repository_reliability.py
+++ b/tests/unit/test_vector_repository_reliability.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for vector repository overflow detection and retry logic.
+
+Tests the reliability improvements in PR #31:
+- Point ID overflow detection
+- Qdrant retry logic with exponential backoff
+"""
+
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from services.vector_service.vector_repository import (
+    VectorRepository,
+    _retry_qdrant,
+    _MAX_ITEMS_PER_TYPE,
+    _OVERFLOW_WARNING_THRESHOLD,
+)
+
+
+class TestPointIDOverflow:
+    """Test point ID overflow detection (#16)."""
+
+    def test_overflow_at_max_items(self):
+        """Point ID should raise ValueError at 1M items."""
+        repo = VectorRepository(
+            qdrant_client=MagicMock(),
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        # Should raise at exactly 1M
+        with pytest.raises(ValueError, match="Point ID overflow.*exceeds max"):
+            repo._compute_point_id("tool", _MAX_ITEMS_PER_TYPE)
+
+        # Should raise above 1M
+        with pytest.raises(ValueError, match="Point ID overflow"):
+            repo._compute_point_id("tool", _MAX_ITEMS_PER_TYPE + 1)
+
+    def test_no_overflow_below_max(self):
+        """Point IDs below 1M should work fine."""
+        repo = VectorRepository(
+            qdrant_client=MagicMock(),
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        # Should work at 999,999
+        point_id = repo._compute_point_id("tool", _MAX_ITEMS_PER_TYPE - 1)
+        assert point_id == 999_999  # tool offset is 0
+
+    def test_warning_at_threshold(self, caplog):
+        """Should warn at 900K items (90% capacity)."""
+        repo = VectorRepository(
+            qdrant_client=MagicMock(),
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        with caplog.at_level("WARNING"):
+            repo._compute_point_id("tool", _OVERFLOW_WARNING_THRESHOLD)
+
+        assert "approaching limit" in caplog.text.lower()
+        assert "900000" in caplog.text or "900,000" in caplog.text
+
+    def test_offset_calculation(self):
+        """Verify offset calculation for different types."""
+        repo = VectorRepository(
+            qdrant_client=MagicMock(),
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        # tool: offset 0
+        assert repo._compute_point_id("tool", 42) == 42
+
+        # prompt: offset 1M
+        assert repo._compute_point_id("prompt", 42) == 1_000_042
+
+        # resource: offset 2M
+        assert repo._compute_point_id("resource", 42) == 2_000_042
+
+
+class TestQdrantRetry:
+    """Test Qdrant retry logic with exponential backoff (#16)."""
+
+    @pytest.mark.asyncio
+    async def test_success_on_first_try(self):
+        """Operation succeeding on first try should not retry."""
+        call_count = 0
+
+        async def success_func():
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        result = await _retry_qdrant(success_func, "test operation")
+        assert result == "success"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_transient_failure(self):
+        """Should retry on transient failures with exponential backoff."""
+        call_count = 0
+
+        async def flaky_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("Transient failure")
+            return "success"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await _retry_qdrant(flaky_func, "test operation", max_retries=3)
+
+        assert result == "success"
+        assert call_count == 3
+        # Check exponential backoff delays: 0.5s, 1.0s
+        assert mock_sleep.call_count == 2
+        assert mock_sleep.call_args_list[0][0][0] == 0.5  # First retry delay
+        assert mock_sleep.call_args_list[1][0][0] == 1.0  # Second retry delay
+
+    @pytest.mark.asyncio
+    async def test_exhausted_retries(self):
+        """Should raise last exception after all retries exhausted."""
+        call_count = 0
+
+        async def always_fails():
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError(f"Failure {call_count}")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ConnectionError, match="Failure 3"):
+                await _retry_qdrant(always_fails, "test operation", max_retries=3)
+
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_different_exceptions(self):
+        """Should retry on any exception type."""
+        call_count = 0
+
+        async def multi_exception_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("First failure")
+            elif call_count == 2:
+                raise RuntimeError("Second failure")
+            return "success"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await _retry_qdrant(multi_exception_func, "test", max_retries=3)
+
+        assert result == "success"
+        assert call_count == 3
+
+
+class TestVectorOperationsWithRetry:
+    """Test that delete and upsert operations use retry logic."""
+
+    @pytest.mark.asyncio
+    async def test_delete_vector_retries_on_failure(self):
+        """delete_vector should retry on Qdrant failures."""
+        mock_client = AsyncMock()
+        # Fail twice, then succeed
+        mock_client.delete_points.side_effect = [
+            ConnectionError("Fail 1"),
+            ConnectionError("Fail 2"),
+            "operation_id_123",
+        ]
+
+        repo = VectorRepository(
+            qdrant_client=mock_client,
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await repo.delete_vector(42)
+
+        assert result is True
+        assert mock_client.delete_points.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_upsert_vector_retries_on_failure(self):
+        """upsert_vector should retry on Qdrant failures."""
+        mock_client = AsyncMock()
+        # Fail once, then succeed
+        mock_client.upsert_points.side_effect = [
+            ConnectionError("Transient failure"),
+            "operation_id_456",
+        ]
+
+        repo = VectorRepository(
+            qdrant_client=mock_client,
+            collection_name="test",
+            embedding_dimension=1536,
+        )
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await repo.upsert_vector(
+                item_id=42,
+                item_type="tool",
+                embedding=[0.1] * 1536,
+                metadata={"name": "test_tool"},
+            )
+
+        assert result is True
+        assert mock_client.upsert_points.call_count == 2


### PR DESCRIPTION
## Summary
- Add overflow detection in _compute_point_id: error at 1M, warn at 900K capacity (#16)
- Add _retry_qdrant helper with exponential backoff for transient Qdrant failures (#16)
- Add CACHE_VERSION prefix to auto-invalidate stale data on schema changes (#17)
- Fix invalidate_pattern to loop batched SCAN for large key sets (#17)

## Test plan
- [ ] Verify ValueError raised when db_id >= 1M for any type
- [ ] Verify warning logged when db_id >= 900K
- [ ] Verify Qdrant upsert/delete retry up to 3 times with backoff
- [ ] Verify cache keys include version prefix (mcp:cache:v1:)
- [ ] Verify pattern invalidation handles >10K keys via batched loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)